### PR TITLE
Updated settings icon since it is not an overlay menu

### DIFF
--- a/NUXT/components/topNavigation.vue
+++ b/NUXT/components/topNavigation.vue
@@ -44,7 +44,7 @@
       class="ml-4 mr-2 my-auto fill-height"
       style="border-radius: 0.25rem !important"
       to="/settings"
-      ><v-icon>mdi-dots-vertical</v-icon></v-btn
+      ><v-icon>mdi-cog-outline</v-icon></v-btn
     >
   </v-card>
 </template>

--- a/android/app/src/main/assets/capacitor.config.json
+++ b/android/app/src/main/assets/capacitor.config.json
@@ -10,16 +10,16 @@
 	"plugins": {
 		"SplashScreen": {
 			"launchShowDuration": 100,
-			"launchAutoHide": true,
+			"launchAutoHide": false,
 			"backgroundColor": "#111111",
 			"androidSplashResourceName": "splash",
 			"androidScaleType": "CENTER_CROP",
 			"androidSpinnerStyle": "large",
 			"iosSpinnerStyle": "small",
 			"spinnerColor": "#999999",
-			"showSpinner": true,
-			"splashFullScreen": true,
-			"splashImmersive": true
+			"showSpinner": false,
+			"splashFullScreen": false,
+			"splashImmersive": false
 		}
 	}
 }


### PR DESCRIPTION
### Changes

Updated the settings icon on the toolbar to a cog (gear) icon. This is because the current settings page is not an overlay menu, and the three-dot icon is designed for use in overlay menus.

### Demonstration

[Screenshots here](https://photos.app.goo.gl/EDmoLhiVXr3m9kdv5)