### PR TITLE
Cache home feed

### DIFF
--- a/NUXT/components/topNavigation.vue
+++ b/NUXT/components/topNavigation.vue
@@ -30,6 +30,15 @@
     <v-spacer v-if="!search" />
 
     <v-btn
+      v-show="page == 'Home'"
+      icon
+      tile
+      class="ml-3 mr-1 my-auto fill-height"
+      style="border-radius: 0.25rem !important"
+      @click="refreshRecommendations"
+      ><v-icon>mdi-refresh</v-icon></v-btn
+    >
+    <v-btn
       icon
       tile
       class="ml-3 my-auto fill-height"
@@ -65,6 +74,18 @@ export default {
   data: () => ({
     text: "",
   }),
+  methods: {
+    refreshRecommendations() {
+      this.$emit("scroll-to-top");
+      this.$store.commit("updateRecommendedVideos", []);
+      this.$youtube
+        .recommend()
+        .then((result) => {
+          if (result) this.$store.commit("updateRecommendedVideos", result[0]);
+        })
+        .catch((error) => this.$logger("Home Page (Nav Refresh)", error, true));
+    },
+  },
 };
 </script>
 

--- a/NUXT/layouts/default.vue
+++ b/NUXT/layouts/default.vue
@@ -6,6 +6,7 @@
       @close-search="search = !search"
       @search-btn="searchBtn"
       @text-changed="textChanged"
+      @scroll-to-top="$refs.pgscroll.scrollTop = 0"
     />
 
     <div class="accent" style="height: 100%; margin-top: 4rem">

--- a/NUXT/pages/home.vue
+++ b/NUXT/pages/home.vue
@@ -4,28 +4,36 @@
   * This is to allow use of "recommended" videos on other pages such as /watch
   * -Front
   * -->
-  <horizontal-list-renderer :recommends="recommends" />
+  <horizontal-list-renderer :recommends="recommends" class="video-list" />
 </template>
 
 <script>
 import horizontalListRenderer from "../components/horizontalListRenderer.vue";
 export default {
   components: { horizontalListRenderer },
-  data() {
-    return {
-      recommends: [],
-    };
+
+  computed: {
+    recommends: {
+      get() {
+        return this.$store.state.recommendedVideos;
+      },
+      set(val) {
+        this.$store.commit("updateRecommendedVideos", val);
+      },
+    },
   },
 
   // The following code is only a demo for debugging purposes, note that each "shelfRenderer" has a "title" value that seems to align to the categories at the top of the vanilla yt app
 
   mounted() {
-    this.$youtube
-      .recommend()
-      .then((result) => {
-        if (result) this.recommends = result[0];
-      })
-      .catch((error) => this.$logger("Home Page", error, true));
+    if (!this.recommends.length) {
+      this.$youtube
+        .recommend()
+        .then((result) => {
+          if (result) this.recommends = result[0];
+        })
+        .catch((error) => this.$logger("Home Page", error, true));
+    }
   },
 };
 </script>

--- a/NUXT/store/index.js
+++ b/NUXT/store/index.js
@@ -1,1 +1,11 @@
-/* activate vuex store */
+import Vue from "vue";
+
+export const state = () => ({
+  recommendedVideos: [],
+});
+
+export const mutations = {
+  updateRecommendedVideos(state, payload) {
+    Vue.set(state, "recommendedVideos", payload);
+  },
+};


### PR DESCRIPTION
Keeps the Home feed cached between pages to improve performance. Will still refresh home feed when app restarts. A refresh button was also added to the top-bar to refresh manually (home page only). Closes #179.

[Video demonstration here](https://photos.app.goo.gl/mZeb8kSAYQGjHGvw9)