### PR TITLE
fix for cached home feed

### DIFF
--- a/NUXT/pages/home.vue
+++ b/NUXT/pages/home.vue
@@ -32,7 +32,7 @@ export default {
   // The following code is only a demo for debugging purposes, note that each "shelfRenderer" has a "title" value that seems to align to the categories at the top of the vanilla yt app
 
   mounted() {
-    if (!this.recommends.length) {
+    if (!this.recommends.items || !this.recommends.items.length) {
       this.$youtube
         .recommend()
         .then((result) => {


### PR DESCRIPTION
Fixed issue where the home feed would always refresh again after going back. The issue was caused by a prior change in the format of the video feed - instead of being an array, it is now an object containing an array. Route watcher was updated to reflect this.

[Fixed behavior demonstration](https://photos.app.goo.gl/D74HT2oKC3r7oSQy9)